### PR TITLE
fix: handleDivide にゼロ除算ガードと入力バリデーションを追加

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,25 @@
+func handleDivide(w http.ResponseWriter, r *http.Request) {
+	aStr := r.URL.Query().Get("a")
+	bStr := r.URL.Query().Get("b")
+
+	a, err := strconv.Atoi(aStr)
+	if err != nil {
+		http.Error(w, "invalid parameter: a", http.StatusBadRequest)
+		return
+	}
+	b, err := strconv.Atoi(bStr)
+	if err != nil {
+		http.Error(w, "invalid parameter: b", http.StatusBadRequest)
+		return
+	}
+
+	// ゼロ除算ガード
+	if b == 0 {
+		http.Error(w, "division by zero: b must not be 0", http.StatusBadRequest)
+		return
+	}
+
+	result := a / b
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]int{"result": result})
+}


### PR DESCRIPTION
## 🤖 AI Agent による自動修正PR

### 根本原因
main.go の handleDivide 関数において、クエリパラメータ b の入力値バリデーションが欠如している。strconv.Atoi のエラーが無視（_ で破棄）されており、かつ b == 0 のガードがないため、b=0 や不正値・未指定時にゼロ除算パニックが発生する。

### 修正内容
handleDivide 関数に strconv.Atoi のエラーハンドリングと b == 0 のゼロ除算ガードを追加し、不正な入力時にはパニックではなく HTTP 400 Bad Request を返すように修正する。

### 分析サマリー
## エラー概要

Cloud Run上の `example-api` サービスで、`GET /api/divide?a=10&b=0` リクエストに対し **HTTP 500 Internal Server Error** が発生しました。

### 原因
`main.go` の `handleDivide` 関数（89行目付近）で、クエリパラメータ `b=0` がバリデーションなしにそのまま除算に使用されており、**整数のゼロ除算（division by zero）パニック**が発生しています。

さらに `strconv.Atoi` のエラーが `_` で無視されているため、`b` が未指定・不正値の場合もデフォルト値 `0` となりパニックします。

### 影響
- パニックにより当該リクエストが500エラーで失敗
- Cloud Runインスタンスのクラッシュ・再起動の可能性
- `b=0` や `b` 未指定のリクエストが来るたびに再発する

---
*このPRはGCPエラーログを検知したAI Agentによって自動作成されました*